### PR TITLE
Merging r367981:

### DIFF
--- a/.github/workflows/commit-tests.yml
+++ b/.github/workflows/commit-tests.yml
@@ -3,7 +3,11 @@ name: Commit Tests
 env:
   release_major: 9
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'releases/**'
+    pull_request:
 
 jobs:
   build_llvm:

--- a/.github/workflows/commit-tests.yml
+++ b/.github/workflows/commit-tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - 'releases/**'
-    pull_request:
+  pull_request:
 
 jobs:
   build_llvm:

--- a/.github/workflows/commit-tests.yml
+++ b/.github/workflows/commit-tests.yml
@@ -48,17 +48,20 @@ jobs:
             # FIXME: Referencing the env context does not work here
             # ref: llvmorg-${{ env.release_major }}.0.0
             ref: llvmorg-9.0.0
+            repo: llvm/llvm-project
           - name: build-latest
             ref: ${{ github.sha }}
+            repo: ${{ env.GITHUB_REPOSITORY }}
     steps:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@master
     - name: Install abi-compliance-checker
       run: sudo apt-get install abi-dumper
     - name: Download source code
-      uses: llvm/actions/get-llvm-project-src@master
+      uses: tstellar/actions/get-llvm-project-src@src-repo
       with:
         ref: ${{ matrix.ref }}
+        repo: ${{ matrix.repo }}
     - name: Configure
       run: |
         mkdir build

--- a/.github/workflows/commit-tests.yml
+++ b/.github/workflows/commit-tests.yml
@@ -51,7 +51,7 @@ jobs:
             repo: llvm/llvm-project
           - name: build-latest
             ref: ${{ github.sha }}
-            repo: ${{ env.GITHUB_REPOSITORY }}
+            repo: ${{ github.repository }}
     steps:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@master


### PR DESCRIPTION
------------------------------------------------------------------------
r367981 | maskray | 2019-08-05 23:25:32 -0700 (Mon, 05 Aug 2019) | 27 lines

[Driver] Prioritize SYSROOT/usr/include over RESOURCE_DIR/include on linux-musl

On a musl-based Linux distribution, stdalign.h stdarg.h stdbool.h stddef.h stdint.h stdnoreturn.h are expected to be provided by musl (/usr/include), instead of RESOURCE_DIR/include.
Reorder RESOURCE_DIR/include to fix the search order problem.
(Currently musl doesn't provide stdatomic.h. stdatomic.h is still found in RESOURCE_DIR/include.)

gcc on musl has a similar search order:

```
 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../include/c++/8.3.0
 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../include/c++/8.3.0/x86_64-alpine-linux-musl
 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../include/c++/8.3.0/backward
 /usr/local/include
 /usr/include/fortify
 /usr/include
 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/include
```

This is different from a glibc-based distribution where RESOURCE_DIR/include is placed before SYSROOT/usr/include.

According to the maintainer of musl:

> musl does not support use/mixing of compiler-provided std headers with its headers, and intentionally has no mechanism for communicating with such headers as to which types have already been defined or still need to be defined. If the current include order, with clang's headers before the libc ones, works in some situations, it's only by accident.

Reviewed by: phosek

Differential Revision: https://reviews.llvm.org/D65699
------------------------------------------------------------------------