### PR TITLE
Release note: `-ffp-exception-behavior=<value>` in llvm 10.0

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -184,6 +184,13 @@ New Compiler Flags
 - ``-mbranches-within-32B-boundaries`` is added as an x86 assembler mitigation
   for Intel's Jump Condition Code Erratum.
 
+- -ffp-exception-behavior={ignore,maytrap,strict} allows the user to specify
+  the floating-point exception behavior.  The default setting is ``ignore``.
+
+- -ffp-model={precise,strict,fast} provides the user an umbrella option to
+  simplify access to the many single purpose floating point options. The default
+  setting is ``precise``.
+
 Deprecated Compiler Flags
 -------------------------
 


### PR DESCRIPTION
https://llvm.org/PR45421