### PR TITLE
[PowerPC] Update alignment for ReuseLoadInfo in LowerFP_TO_INTForReuse

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -7720,15 +7720,17 @@ void PPCTargetLowering::LowerFP_TO_INTForReuse(SDValue Op, ReuseLoadInfo &RLI,
 
   // Emit a store to the stack slot.
   SDValue Chain;
+  unsigned Alignment = DAG.getEVTAlignment(Tmp.getValueType());
   if (i32Stack) {
     MachineFunction &MF = DAG.getMachineFunction();
+    Alignment = 4;
     MachineMemOperand *MMO =
-      MF.getMachineMemOperand(MPI, MachineMemOperand::MOStore, 4, 4);
+      MF.getMachineMemOperand(MPI, MachineMemOperand::MOStore, 4, Alignment);
     SDValue Ops[] = { DAG.getEntryNode(), Tmp, FIPtr };
     Chain = DAG.getMemIntrinsicNode(PPCISD::STFIWX, dl,
               DAG.getVTList(MVT::Other), Ops, MVT::i32, MMO);
   } else
-    Chain = DAG.getStore(DAG.getEntryNode(), dl, Tmp, FIPtr, MPI);
+    Chain = DAG.getStore(DAG.getEntryNode(), dl, Tmp, FIPtr, MPI, Alignment);
 
   // Result is a load from the stack slot.  If loading 4 bytes, make sure to
   // add in a bias on big endian.
@@ -7741,6 +7743,7 @@ void PPCTargetLowering::LowerFP_TO_INTForReuse(SDValue Op, ReuseLoadInfo &RLI,
   RLI.Chain = Chain;
   RLI.Ptr = FIPtr;
   RLI.MPI = MPI;
+  RLI.Alignment = Alignment;
 }
 
 /// Custom lowers floating point to integer conversions to use

--- a/llvm/test/CodeGen/PowerPC/kernel-fp-round.ll
+++ b/llvm/test/CodeGen/PowerPC/kernel-fp-round.ll
@@ -1,0 +1,44 @@
+; RUN: llc -simplify-mir -verify-machineinstrs -stop-after=finalize-isel \
+; RUN:   -mtriple=powerpc64le-unknown-unknown -mattr=-vsx < %s | FileCheck %s
+; RUN: llc -simplify-mir -verify-machineinstrs -stop-after=finalize-isel \
+; RUN:   -mtriple=powerpc-unknown-unknown -mcpu=pwr6 -mattr=-vsx < %s | \
+; RUN:   FileCheck --check-prefix=CHECK-P6 %s
+; RUN: llc -simplify-mir -verify-machineinstrs -stop-after=finalize-isel \
+; RUN:   -mtriple=powerpc64-unknown-unknown -mcpu=pwr6 -mattr=-vsx < %s | \
+; RUN:   FileCheck --check-prefix=CHECK-P6-64 %s
+
+define float @test(float %a) {
+; CHECK:        stack:
+; CHECK-NEXT:   - { id: 0, size: 4, alignment: 4 }
+; CHECK:        %2:f8rc = FCTIWZ killed %1, implicit $rm
+; CHECK:        STFIWX killed %2, $zero8, %3
+; CHECK-NEXT:   %4:f8rc = LFIWAX $zero8, %3 :: (load 4 from %stack.0)
+; CHECK-NEXT:   %5:f4rc = FCFIDS killed %4, implicit $rm
+; CHECK-NEXT:   $f1 = COPY %5
+; CHECK-NEXT:   BLR8 implicit $lr8, implicit $rm, implicit $f1
+
+; CHECK-P6:        stack:
+; CHECK-P6-NEXT:   - { id: 0, size: 4, alignment: 4 }
+; CHECK-P6:        %2:f8rc = FCTIWZ killed %1, implicit $rm
+; CHECK-P6:        STFIWX killed %2, $zero, %3
+; CHECK-P6-NEXT:   %4:f8rc = LFIWAX $zero, %3 :: (load 4 from %stack.0)
+; CHECK-P6-NEXT:   %5:f8rc = FCFID killed %4, implicit $rm
+; CHECK-P6-NEXT:   %6:f4rc = FRSP killed %5, implicit $rm
+; CHECK-P6-NEXT:   $f1 = COPY %6
+; CHECK-P6-NEXT:   BLR implicit $lr, implicit $rm, implicit $f1
+
+; CHECK-P6-64:        stack:
+; CHECK-P6-64-NEXT:   - { id: 0, size: 4, alignment: 4 }
+; CHECK-P6-64:        %2:f8rc = FCTIWZ killed %1, implicit $rm
+; CHECK-P6-64:        STFIWX killed %2, $zero8, %3
+; CHECK-P6-64-NEXT:   %4:f8rc = LFIWAX $zero8, %3 :: (load 4 from %stack.0)
+; CHECK-P6-64-NEXT:   %5:f8rc = FCFID killed %4, implicit $rm
+; CHECK-P6-64-NEXT:   %6:f4rc = FRSP killed %5, implicit $rm
+; CHECK-P6-64-NEXT:   $f1 = COPY %6
+; CHECK-P6-64-NEXT:   BLR8 implicit $lr8, implicit $rm, implicit $f1
+
+entry:
+  %b = fptosi float %a to i32
+  %c = sitofp i32 %b to float
+  ret float %c
+}


### PR DESCRIPTION
In LowerFP_TO_INTForReuse, when emitting `stfiwx`, alignment of 4 is
set for the `MachineMemOperand`, but RLI(ReuseLoadInfo)'s alignment is
not updated for following loads.

It's related to failed alignment check reported in
https://bugs.llvm.org/show_bug.cgi?id=45297

Differential Revision: https://reviews.llvm.org/D77624

Backport b7d5229d789b7cb2747226d528ed016624b11cea.