### PR TITLE
Fix alignment of thunks for ARM/ARM64

### DIFF
--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -486,7 +486,9 @@ public:
 
 class ImportThunkChunkARM : public ImportThunkChunk {
 public:
-  explicit ImportThunkChunkARM(Defined *s) : ImportThunkChunk(s) {}
+  explicit ImportThunkChunkARM(Defined *s) : ImportThunkChunk(s) {
+    setAlignment(2);
+  }
   size_t getSize() const override { return sizeof(importThunkARM); }
   void getBaserels(std::vector<Baserel> *res) override;
   void writeTo(uint8_t *buf) const override;
@@ -494,14 +496,16 @@ public:
 
 class ImportThunkChunkARM64 : public ImportThunkChunk {
 public:
-  explicit ImportThunkChunkARM64(Defined *s) : ImportThunkChunk(s) {}
+  explicit ImportThunkChunkARM64(Defined *s) : ImportThunkChunk(s) {
+    setAlignment(4);
+  }
   size_t getSize() const override { return sizeof(importThunkARM64); }
   void writeTo(uint8_t *buf) const override;
 };
 
 class RangeExtensionThunkARM : public NonSectionChunk {
 public:
-  explicit RangeExtensionThunkARM(Defined *t) : target(t) {}
+  explicit RangeExtensionThunkARM(Defined *t) : target(t) { setAlignment(2); }
   size_t getSize() const override;
   void writeTo(uint8_t *buf) const override;
 

--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -365,7 +365,9 @@ public:
 
 class ThunkChunkARM : public NonSectionChunk {
 public:
-  ThunkChunkARM(Defined *i, Chunk *tm) : imp(i), tailMerge(tm) {}
+  ThunkChunkARM(Defined *i, Chunk *tm) : imp(i), tailMerge(tm) {
+    setAlignment(2);
+  }
 
   size_t getSize() const override { return sizeof(thunkARM); }
 
@@ -385,7 +387,9 @@ public:
 
 class TailMergeChunkARM : public NonSectionChunk {
 public:
-  TailMergeChunkARM(Chunk *d, Defined *h) : desc(d), helper(h) {}
+  TailMergeChunkARM(Chunk *d, Defined *h) : desc(d), helper(h) {
+    setAlignment(2);
+  }
 
   size_t getSize() const override { return sizeof(tailMergeARM); }
 
@@ -405,7 +409,9 @@ public:
 
 class ThunkChunkARM64 : public NonSectionChunk {
 public:
-  ThunkChunkARM64(Defined *i, Chunk *tm) : imp(i), tailMerge(tm) {}
+  ThunkChunkARM64(Defined *i, Chunk *tm) : imp(i), tailMerge(tm) {
+    setAlignment(4);
+  }
 
   size_t getSize() const override { return sizeof(thunkARM64); }
 
@@ -422,7 +428,9 @@ public:
 
 class TailMergeChunkARM64 : public NonSectionChunk {
 public:
-  TailMergeChunkARM64(Chunk *d, Defined *h) : desc(d), helper(h) {}
+  TailMergeChunkARM64(Chunk *d, Defined *h) : desc(d), helper(h) {
+    setAlignment(4);
+  }
 
   size_t getSize() const override { return sizeof(tailMergeARM64); }
 

--- a/lld/test/COFF/arm64-import2.test
+++ b/lld/test/COFF/arm64-import2.test
@@ -11,18 +11,20 @@
 # BEFORE:        0:       00 00 00 94     bl      #0
 # BEFORE:        4:       00 00 00 94     bl      #0
 # BEFORE:        8:       c0 03 5f d6     ret
+# BEFORE:        c:       ff              <unknown>
 
 # AFTER: Disassembly of section .text:
 # AFTER-EMPTY:
-# AFTER:  140001000:      03 00 00 94     bl      #12
-# AFTER:  140001004:      05 00 00 94     bl      #20
+# AFTER:  140001000:      04 00 00 94     bl      #16
+# AFTER:  140001004:      06 00 00 94     bl      #24
 # AFTER:  140001008:      c0 03 5f d6     ret
-# AFTER:  14000100c:      10 00 00 b0     adrp    x16, #4096
-# AFTER:  140001010:      10 32 40 f9     ldr     x16, [x16, #96]
-# AFTER:  140001014:      00 02 1f d6     br      x16
-# AFTER:  140001018:      10 00 00 b0     adrp    x16, #4096
-# AFTER:  14000101c:      10 3a 40 f9     ldr     x16, [x16, #112]
-# AFTER:  140001020:      00 02 1f d6     br      x16
+# AFTER:  14000100c:      ff cc cc cc     <unknown>
+# AFTER:  140001010:      10 00 00 b0     adrp    x16, #4096
+# AFTER:  140001014:      10 32 40 f9     ldr     x16, [x16, #96]
+# AFTER:  140001018:      00 02 1f d6     br      x16
+# AFTER:  14000101c:      10 00 00 b0     adrp    x16, #4096
+# AFTER:  140001020:      10 3a 40 f9     ldr     x16, [x16, #112]
+# AFTER:  140001024:      00 02 1f d6     br      x16
 
 # IMPORTS: Import {
 # IMPORTS:   Name: library.dll
@@ -45,7 +47,7 @@ sections:
   - Name:            .text
     Characteristics: [ IMAGE_SCN_CNT_CODE, IMAGE_SCN_MEM_EXECUTE, IMAGE_SCN_MEM_READ ]
     Alignment:       4
-    SectionData:     0000009400000094C0035FD6
+    SectionData:     0000009400000094C0035FD6FF
     Relocations:
       - VirtualAddress:  0
         SymbolName:      function


### PR DESCRIPTION
The alignment of ARM64 range extension thunks was fixed in
7c816492197a, but ARM range extension thunks, and import
and delay import thunks also need aligning (like all code on ARM
platforms).

I'm adding a test for alignment of ARM64 import thunks - not
specifically adding tests for misalignment of all of them though.

Differential Revision: https://reviews.llvm.org/D77796

(cherry picked from commit 12c9e2f1110a4fc73562214cf5dd0194b31e87cf)