### PR TITLE
[InstCombine] prevent infinite loop with sub/abs of constant expression

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1768,7 +1768,7 @@ Instruction *InstCombiner::visitSub(BinaryOperator &I) {
     Constant *C2;
 
     // C-(C2-X) --> X+(C-C2)
-    if (match(Op1, m_Sub(m_Constant(C2), m_Value(X))))
+    if (match(Op1, m_Sub(m_Constant(C2), m_Value(X))) && !isa<ConstantExpr>(C2))
       return BinaryOperator::CreateAdd(X, ConstantExpr::getSub(C, C2));
 
     // C-(X+C2) --> (C-C2)-X

--- a/llvm/test/Transforms/InstCombine/abs-1.ll
+++ b/llvm/test/Transforms/InstCombine/abs-1.ll
@@ -569,3 +569,21 @@ define i1 @abs_must_be_positive(i32 %x) {
   ret i1 %c2
 }
 
+@g = external global i64
+
+; PR45539 - https://bugs.llvm.org/show_bug.cgi?id=45539
+
+define i64 @infinite_loop_constant_expression_abs(i64 %arg) {
+; CHECK-LABEL: @infinite_loop_constant_expression_abs(
+; CHECK-NEXT:    [[T:%.*]] = sub i64 ptrtoint (i64* @g to i64), [[ARG:%.*]]
+; CHECK-NEXT:    [[T1:%.*]] = icmp slt i64 [[T]], 0
+; CHECK-NEXT:    [[T2:%.*]] = sub nsw i64 0, [[T]]
+; CHECK-NEXT:    [[T3:%.*]] = select i1 [[T1]], i64 [[T2]], i64 [[T]]
+; CHECK-NEXT:    ret i64 [[T3]]
+;
+  %t = sub i64 ptrtoint (i64* @g to i64), %arg
+  %t1 = icmp slt i64 %t, 0
+  %t2 = sub nsw i64 0, %t
+  %t3 = select i1 %t1, i64 %t2, i64 %t
+  ret i64 %t3
+}


### PR DESCRIPTION
PR45539:
https://bugs.llvm.org/show_bug.cgi?id=45539

(cherry picked from commit 01bcc3e9371470e1974f066ced353df15e10056d)