### PR TITLE
Please backport 88aad9b9f05 (lit googletest.py: Don't raise StopIteration in generator) to 10.x

### DIFF
--- a/llvm/utils/lit/lit/formats/googletest.py
+++ b/llvm/utils/lit/lit/formats/googletest.py
@@ -41,7 +41,7 @@ class GoogleTest(TestFormat):
             litConfig.warning(
                 "unable to discover google-tests in %r: %s. Process output: %s"
                 % (path, sys.exc_info()[1], exc.output))
-            raise StopIteration
+            return
 
         nested_tests = []
         for ln in output.splitlines(False):  # Don't keep newlines.


### PR DESCRIPTION
https://llvm.org/PR46051