### PR TITLE
[PPCAsmPrinter] support 'L' output template for memory operands

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -298,6 +298,11 @@ bool PPCAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
 
     switch (ExtraCode[0]) {
     default: return true;  // Unknown modifier.
+    case 'L': // A memory reference to the upper word of a double word op.
+      O << getDataLayout().getPointerSize() << "(";
+      printOperand(MI, OpNo, O);
+      O << ")";
+      return false;
     case 'y': // A memory reference for an X-form instruction
       {
         const char *RegName = "r0";
@@ -309,7 +314,6 @@ bool PPCAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
       }
     case 'U': // Print 'u' for update form.
     case 'X': // Print 'x' for indexed form.
-    {
       // FIXME: Currently for PowerPC memory operands are always loaded
       // into a register, so we never get an update or indexed form.
       // This is bad even for offset forms, since even if we know we
@@ -318,7 +322,6 @@ bool PPCAsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
       // tolerate 'U' and 'X' but don't output anything.
       assert(MI->getOperand(OpNo).isReg());
       return false;
-    }
     }
   }
 

--- a/llvm/test/CodeGen/PowerPC/inlineasm-output-template.ll
+++ b/llvm/test/CodeGen/PowerPC/inlineasm-output-template.ll
@@ -1,4 +1,5 @@
-; RUN: llc -mtriple=ppc32-- < %s | FileCheck %s
+; RUN: llc -mtriple=ppc32 < %s | FileCheck %s
+; RUN: llc -mtriple=ppc64 < %s | FileCheck %s --check-prefix=PPC64
 
 ; Test that %c works with immediates
 ; CHECK-LABEL: test_inlineasm_c_output_template0
@@ -23,4 +24,14 @@ define dso_local i32 @test_inlineasm_c_output_template1() {
 define dso_local i32 @test_inlineasm_c_output_template2() {
   tail call void asm sideeffect "#TEST ${0:n}", "i"(i32 42)
   ret i32 42
+}
+
+; Test that the machine specific %L works with memory operands.
+; CHECK-LABEL: test_inlineasm_L_output_template
+; CHECK: # 4(5)
+; PPC64-LABEL: test_inlineasm_L_output_template
+; PPC64: # 8(4)
+define dso_local void @test_inlineasm_L_output_template(i64 %0, i64* %1) {
+  tail call void asm sideeffect "# ${0:L}", "*m"(i64* %1)
+  ret void
 }


### PR DESCRIPTION
Summary:
L is meant to support the second word used by 32b calling conventions for 64b arguments.

This is required for build 32b PowerPC Linux kernels after upstream
commit 334710b1496a ("powerpc/uaccess: Implement unsafe_put_user() using 'asm goto'")

Thanks for the report from @nathanchance, and reference to GCC's
implementation from @segher.

Fixes: pr/46186
Fixes: https://github.com/ClangBuiltLinux/linux/issues/1044

Reviewers: echristo, hfinkel, MaskRay

Reviewed By: MaskRay

Subscribers: MaskRay, wuzish, nemanjai, hiraditya, kbarton, steven.zhang, llvm-commits, segher, nathanchance, srhines

Tags: #llvm

Differential Revision: https://reviews.llvm.org/D81767

(cherry picked from commit 2d8e105db6bea10a6b96e4a094e73a87987ef909)