### PR TITLE
[compiler-rt] Reduce the number of threads in gcov test to avoid failure

### DIFF
--- a/compiler-rt/test/profile/Inputs/instrprof-gcov-multithread_fork.cpp
+++ b/compiler-rt/test/profile/Inputs/instrprof-gcov-multithread_fork.cpp
@@ -1,27 +1,17 @@
 #include <sys/types.h>
 #include <thread>
 #include <unistd.h>
-#include <vector>
 
 template <typename T>
 void launcher(T func) {
-  std::vector<std::thread> pool;
+  auto t1 = std::thread(func);
+  auto t2 = std::thread(func);
 
-  for (int i = 0; i < 10; i++) {
-    pool.emplace_back(std::thread(func));
-  }
-
-  for (auto &t : pool) {
-    t.join();
-  }
+  t1.join();
+  t2.join();
 }
 
-void h() {}
-
-void g() {
-  fork();
-  launcher<>(h);
-}
+void g() {}
 
 void f() {
   fork();


### PR DESCRIPTION
Summary:
Patch in D78477 introduced a new test for gcov and this test is failing on arm:
 - http://lab.llvm.org:8011/builders/clang-cmake-thumbv7-full-sh/builds/4752/steps/ninja%20check%202/logs/stdio
  - http://lab.llvm.org:8011/builders/clang-cmake-armv7-full/builds/10501/steps/ninja%20check%202/logs/stdio
So try to fix it in reducing the number of threads.

Reviewers: marco-c

Reviewed By: marco-c

Subscribers: dberris, kristof.beyls, #sanitizers, serge-sans-paille, sylvestre.ledru

Tags: #sanitizers

Differential Revision: https://reviews.llvm.org/D79621

(cherry picked from commit 0da37bedc2667da371eda30595a06210595881d0)