### PR TITLE
[SemaTemplate] Stop passing insertion position around during VarTempl…

### DIFF
--- a/clang/test/SemaTemplate/instantiate-var-template.cpp
+++ b/clang/test/SemaTemplate/instantiate-var-template.cpp
@@ -40,3 +40,10 @@ namespace PR24483 {
   template<typename... T> A<T...> models;
   template<> struct B models<>; // expected-error {{incomplete type 'struct B'}} expected-note {{forward declaration}}
 }
+
+namespace InvalidInsertPos {
+  template<typename T, int N> T v;
+  template<int N> decltype(v<int, N-1>) v<int, N>;
+  template<> int v<int, 0>;
+  int k = v<int, 500>;
+}


### PR DESCRIPTION
…ate instantiation

They can get stale at use time because of updates from other recursive
specializations. Instead, rely on the existence of previous declarations to add
the specialization.

Differential Revision: https://reviews.llvm.org/D87853

(cherry picked from commit cffb0dd54d41d8e249d2009467c4beb5b681ba26)

This is a re-commit of 8ac709578067f77a7036fe50610277516fa36d50 with
some modifications to avoid changing the clang API.