### PR TITLE
[LLVM 11 regression] MC assembler check, rejects common assembler code as, e.g., generated by GCC

### DIFF
--- a/llvm/lib/MC/MCParser/ELFAsmParser.cpp
+++ b/llvm/lib/MC/MCParser/ELFAsmParser.cpp
@@ -644,10 +644,13 @@ EndStmt:
       !(SectionName == ".eh_frame" && Type == ELF::SHT_PROGBITS))
     Error(loc, "changed section type for " + SectionName + ", expected: 0x" +
                    utohexstr(Section->getType()));
-  if (Section->getFlags() != Flags)
+  // Check that flags are used consistently. However, the GNU assembler permits
+  // to leave out in subsequent uses of the same sections; for compatibility,
+  // do likewise.
+  if ((Flags || Size || !TypeName.empty()) && Section->getFlags() != Flags)
     Error(loc, "changed section flags for " + SectionName + ", expected: 0x" +
                    utohexstr(Section->getFlags()));
-  if (Section->getEntrySize() != Size)
+  if ((Flags || Size || !TypeName.empty()) && Section->getEntrySize() != Size)
     Error(loc, "changed section entsize for " + SectionName +
                    ", expected: " + Twine(Section->getEntrySize()));
 

--- a/llvm/test/MC/ELF/section-flags-changed.s
+++ b/llvm/test/MC/ELF/section-flags-changed.s
@@ -9,4 +9,7 @@ foo:
 # CHECK: {{.*}}.s:[[# @LINE+1]]:1: error: changed section flags for .foo, expected: 0x6
 .pushsection .foo,"a",@progbits
 
+# CHECK: {{.*}}.s:[[# @LINE+1]]:1: error: changed section flags for .foo, expected: 0x6
+.section .foo,"",@progbits
+
 .pushsection .foo,"ax",@progbits

--- a/llvm/test/MC/ELF/section-omitted-attributes.s
+++ b/llvm/test/MC/ELF/section-omitted-attributes.s
@@ -1,0 +1,11 @@
+# RUN: llvm-mc -triple=x86_64 %s -o - | FileCheck %s
+
+# If section flags and other attributes are omitted, don't error.
+
+# CHECK: .section        .foo,"aM",@progbits,1
+
+.section .foo,"aM",@progbits,1
+
+.section .foo
+
+.pushsection .foo


### PR DESCRIPTION
https://llvm.org/PR48201