### PR TITLE
Backport fix for --pgo-warn-misexpect from 12 to 11

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3777,7 +3777,7 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
     }
   }
 
-  if (Diags.isIgnored(diag::warn_profile_data_misexpect, SourceLocation()))
+  if (!Diags.isIgnored(diag::warn_profile_data_misexpect, SourceLocation()))
     Res.FrontendOpts.LLVMArgs.push_back("-pgo-warn-misexpect");
 
   LangOpts.FunctionAlignment =


### PR DESCRIPTION
https://llvm.org/PR48403