### PR TITLE
Backport: "[lldb] Use CompileUnit::ResolveSymbolContext in SymbolFileDWARF"

### DIFF
--- a/lldb/source/Symbol/CompileUnit.cpp
+++ b/lldb/source/Symbol/CompileUnit.cpp
@@ -248,17 +248,6 @@ void CompileUnit::ResolveSymbolContext(const FileSpec &file_spec,
   if (!file_spec_matches_cu_file_spec && !check_inlines)
     return;
 
-  uint32_t file_idx =
-      GetSupportFiles().FindFileIndex(0, file_spec, true);
-  while (file_idx != UINT32_MAX) {
-    file_indexes.push_back(file_idx);
-    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
-  }
-
-  const size_t num_file_indexes = file_indexes.size();
-  if (num_file_indexes == 0)
-    return;
-
   SymbolContext sc(GetModule());
   sc.comp_unit = this;
 
@@ -271,10 +260,25 @@ void CompileUnit::ResolveSymbolContext(const FileSpec &file_spec,
     return;
   }
 
+  uint32_t file_idx =
+      GetSupportFiles().FindFileIndex(0, file_spec, true);
+  while (file_idx != UINT32_MAX) {
+    file_indexes.push_back(file_idx);
+    file_idx = GetSupportFiles().FindFileIndex(file_idx + 1, file_spec, true);
+  }
+
+  const size_t num_file_indexes = file_indexes.size();
+  if (num_file_indexes == 0)
+    return;
+
   LineTable *line_table = sc.comp_unit->GetLineTable();
 
-  if (line_table == nullptr)
+  if (line_table == nullptr) {
+    if (file_spec_matches_cu_file_spec && !check_inlines) {
+      sc_list.Append(sc);
+    }
     return;
+  }
 
   uint32_t line_idx;
   LineEntry line_entry;

--- a/lldb/test/Shell/SymbolFile/DWARF/dwarf5-debug_line-file-index.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwarf5-debug_line-file-index.s
@@ -1,0 +1,119 @@
+# Test handling of DWARF5 file index 0.
+
+# REQUIRES: x86
+
+# RUN: llvm-mc -filetype=obj -o %t -triple x86_64-pc-linux %s
+# RUN: %lldb %t -o "image lookup -f hello.c -l 1" \
+# RUN:   -o exit | FileCheck %s
+
+# CHECK: 2 matches found in hello.c:1
+	.text
+.Lfunc_begin0:
+	.file	0 "." "hello.c"
+	.loc	0 1 0                           # hello.c:1:0
+		nop
+	.loc	0 1 13 prologue_end             # hello.c:1:13
+		nop
+.Lfunc_end0:
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               # Abbreviation Code
+	.byte	17                              # DW_TAG_compile_unit
+	.byte	1                               # DW_CHILDREN_yes
+	.byte	37                              # DW_AT_producer
+	.byte	37                              # DW_FORM_strx1
+	.byte	19                              # DW_AT_language
+	.byte	5                               # DW_FORM_data2
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	114                             # DW_AT_str_offsets_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	16                              # DW_AT_stmt_list
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	27                              # DW_AT_comp_dir
+	.byte	37                              # DW_FORM_strx1
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	115                             # DW_AT_addr_base
+	.byte	23                              # DW_FORM_sec_offset
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	2                               # Abbreviation Code
+	.byte	46                              # DW_TAG_subprogram
+	.byte	0                               # DW_CHILDREN_no
+	.byte	17                              # DW_AT_low_pc
+	.byte	27                              # DW_FORM_addrx
+	.byte	18                              # DW_AT_high_pc
+	.byte	6                               # DW_FORM_data4
+	.byte	64                              # DW_AT_frame_base
+	.byte	24                              # DW_FORM_exprloc
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	58                              # DW_AT_decl_file
+	.byte	11                              # DW_FORM_data1
+	.byte	59                              # DW_AT_decl_line
+	.byte	11                              # DW_FORM_data1
+	.byte	73                              # DW_AT_type
+	.byte	19                              # DW_FORM_ref4
+	.byte	63                              # DW_AT_external
+	.byte	25                              # DW_FORM_flag_present
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	3                               # Abbreviation Code
+	.byte	36                              # DW_TAG_base_type
+	.byte	0                               # DW_CHILDREN_no
+	.byte	3                               # DW_AT_name
+	.byte	37                              # DW_FORM_strx1
+	.byte	62                              # DW_AT_encoding
+	.byte	11                              # DW_FORM_data1
+	.byte	11                              # DW_AT_byte_size
+	.byte	11                              # DW_FORM_data1
+	.byte	0                               # EOM(1)
+	.byte	0                               # EOM(2)
+	.byte	0                               # EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 # Length of Unit
+.Ldebug_info_start0:
+	.short	5                               # DWARF version number
+	.byte	1                               # DWARF Unit Type
+	.byte	8                               # Address Size (in bytes)
+	.long	.debug_abbrev                   # Offset Into Abbrev. Section
+	.byte	1                               # Abbrev [1] 0xc:0x2b DW_TAG_compile_unit
+	.byte	0                               # DW_AT_producer
+	.short	12                              # DW_AT_language
+	.byte	1                               # DW_AT_name
+	.long	.Lstr_offsets_base0             # DW_AT_str_offsets_base
+	.long	.Lline_table_start0             # DW_AT_stmt_list
+	.byte	2                               # DW_AT_comp_dir
+	.byte	0                               # DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       # DW_AT_high_pc
+	.long	.Laddr_table_base0              # DW_AT_addr_base
+.Ldebug_info_end0:
+	.section	.debug_str_offsets,"",@progbits
+	.long	24                              # Length of String Offsets Set
+	.short	5
+	.short	0
+.Lstr_offsets_base0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"" # string offset=0
+.Linfo_string1:
+	.asciz	"hello.c"                       # string offset=101
+.Linfo_string2:
+	.asciz	"."                             # string offset=109
+	.section	.debug_str_offsets,"",@progbits
+	.long	.Linfo_string0
+	.long	.Linfo_string1
+	.long	.Linfo_string2
+	.section	.debug_addr,"",@progbits
+.Ldebug_addr_start0:
+	.short	5                               # DWARF version number
+	.byte	8                               # Address size
+	.byte	0                               # Segment selector size
+.Laddr_table_base0:
+	.quad	.Lfunc_begin0
+.Ldebug_addr_end0:
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:


### PR DESCRIPTION
https://llvm.org/PR50673